### PR TITLE
Bump CLI version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ runs:
         HUBSPOT_PORTAL_ID: ${{ inputs.portal_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
-        npx @hubspot/cms-cli@2.2.0 upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env
+        npx @hubspot/cms-cli@2.2.1 upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env
       shell: bash


### PR DESCRIPTION
The current version 2.2.0 was referencing an incompatible version of cms-lib which has since been fixed