### PR TITLE
corrected version number removed beginning `.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
 To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, add the following step:
 ```yaml
 - name: HubSpot Deploy Action
-  uses: HubSpot/hubspot-cms-deploy-action@v.1.1
+  uses: HubSpot/hubspot-cms-deploy-action@v1.2
   with:
     src_dir: <src>
     dest_dir: <src>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
       - name: HubSpot Deploy Action
-        uses: HubSpot/hubspot-cms-deploy-action@v.1.1
+        uses: HubSpot/hubspot-cms-deploy-action@v1.2
         with:
           src_dir: <src>
           dest_dir: <src>


### PR DESCRIPTION
Configuring GitHub Actions is not something I've done a lot of so would appreciate some eyes.

When testing the action and following the directions in the readme I found the version number was wrong, also the `.` in the version number was causing it to fail.