### PR TITLE
Update CLI version used to HubSpot CLI version 3.0.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ runs:
         HUBSPOT_PORTAL_ID: ${{ inputs.portal_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
-        npx @hubspot/cms-cli@2.2.2 upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env
+        npx @hubspot/cli@3.0.4 upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env
       shell: bash


### PR DESCRIPTION
Update from V2.2.2 to new HubSpot CLI, at version 3.0.4.

I have not tested the update since I don't really know how to test GH actions but the CLI should work as long as environment variables have not changed in the 3.0 version.