### PR TITLE
Upgrade actions/setup-node to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: "20.x"
     - name: Deploy


### PR DESCRIPTION
When I run this action on my repos, I get the following message:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

While I know the node version actually used is 20, I think the underlying action itself might just need a little upgrade.