### PR TITLE
Update actions/setup-node and actions/checkout versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: HubSpot Deploy Action
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: "20.x"
     - name: Deploy


### PR DESCRIPTION
This pull request updates the actions/setup-node and actions/checkout to the latest version.
Using the older versions show deprecation warnings when the hubspot cms deploy action in a workflow.
