### PR TITLE
V2 of CMS Deploy action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Automatically deploy a HubSpot CMS project to your account 🚀
 
-## BREAKING CHANGE in v2
-If you are upgrading from an older version of the GitHub Deploy action, we renamed the `HUBSPOT_PORTAL_ID` secret to now be a variable called `HUBSPOT_ACCOUNT_ID`. This change reflects our efforts to be consistent in how we refer to concepts in HubSpot.
+
 
 ## Usage
-In your GitHub repo, create two new [secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for:
-- `HUBSPOT_ACCOUNT_ID` - This is your HubSpot account ID
+In your GitHub repo, create one new [secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for:
 - `HUBSPOT_PERSONAL_ACCESS_KEY` - Your [personal access key](https://developers.hubspot.com/docs/cms/personal-cms-access-key)
+Then create a [variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository) (in the same interface as secrets)
+- `HUBSPOT_ACCOUNT_ID` - This is your [HubSpot account ID](https://knowledge.hubspot.com/account-management/manage-multiple-hubspot-accounts#:~:text=Check%20your%20current%20account,name%20and%20unique%20Hub%20ID.)
 
 This guide walks through setting up a new workflow file that automatically uploads new changes on your `main` branch to your HubSpot CMS account. If you're adding a deployment step to an existing workflow, you can [skip ahead](#integrating-into-an-existing-workflow).
 
@@ -30,7 +30,7 @@ jobs:
         with:
           src_dir: <src> ## ex. src
           dest_dir: <src> ## ex. my-theme
-          account_id: ${{ secrets.hubspot_portal_id }}
+          account_id: ${{ vars.hubspot_account_id || secrets.hubspot_portal_id }}
           personal_access_key: ${{ secrets.hubspot_personal_access_key }}
 ```
 3. Replace the `src_dir` with the directory of your CMS project in your repo
@@ -47,7 +47,7 @@ on:
     branches:
     - qa
 ...
-account_id: ${{ secrets.staging_account_id }}
+account_id: ${{ vars.hubspot_account_id || secrets.hubspot_portal_id }}
 ```
 
 ### Integrating into an existing workflow
@@ -58,7 +58,7 @@ To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, a
   with:
     src_dir: <src> ## ex. src
     dest_dir: <src> ## ex. my-theme
-    account_id: ${{ secrets.hubspot_portal_id }}
+    account_id: ${{ vars.hubspot_account_id || secrets.hubspot_portal_id }}
     personal_access_key: ${{ secrets.hubspot_personal_access_key }}
 ```
 
@@ -70,5 +70,9 @@ To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, a
 - `dest_dir` - Target directory in HubSpot
 
 ### Secrets
-- `HUBSPOT_ACCOUNT_ID` - Target account id
 - `HUBSPOT_PERSONAL_ACCESS_KEY` - Authentication key
+
+#### Deprecated secret
+- `HUBSPOT_PORTAL_ID` - Target account id. This was deprecated in favor of `HUBSPOT_ACCOUNT_ID`, this is more consistent with how we refer to accounts, additionally we moved it to be a variable since GitHub variables now exist and allow for you to be able to see and modify the value. The Account ID does not need the same protection that an authentication key does.
+### Variables
+- `HUBSPOT_ACCOUNT_ID` - Target account id

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Automatically deploy a HubSpot CMS project to your account 🚀
 ## Usage
 In your GitHub repo, create one new [secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for:
 - `HUBSPOT_PERSONAL_ACCESS_KEY` - Your [personal access key](https://developers.hubspot.com/docs/cms/personal-cms-access-key)
-Then create a [variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository) (in the same interface as secrets)
+
+Then create a [variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository) (in the same interface as secrets):
 - `HUBSPOT_ACCOUNT_ID` - This is your [HubSpot account ID](https://knowledge.hubspot.com/account-management/manage-multiple-hubspot-accounts#:~:text=Check%20your%20current%20account,name%20and%20unique%20Hub%20ID.)
 
 This guide walks through setting up a new workflow file that automatically uploads new changes on your `main` branch to your HubSpot CMS account. If you're adding a deployment step to an existing workflow, you can [skip ahead](#integrating-into-an-existing-workflow).

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v4
       - name: HubSpot Deploy Action
-        uses: HubSpot/hubspot-cms-deploy-action@v1.7
+        uses: HubSpot/hubspot-cms-deploy-action@v2
         with:
           src_dir: <src> ## ex. src
           dest_dir: <src> ## ex. my-theme
@@ -54,7 +54,7 @@ account_id: ${{ vars.hubspot_account_id || secrets.hubspot_portal_id }}
 To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, add the following step:
 ```yaml
 - name: HubSpot Deploy Action
-  uses: HubSpot/hubspot-cms-deploy-action@v1.7
+  uses: HubSpot/hubspot-cms-deploy-action@v2
   with:
     src_dir: <src> ## ex. src
     dest_dir: <src> ## ex. my-theme

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Automatically deploy a HubSpot CMS project to your account 🚀
 
+## BREAKING CHANGE in v2
+If you are upgrading from an older version of the GitHub Deploy action, we renamed the `HUBSPOT_PORTAL_ID` secret to now be a variable called `HUBSPOT_ACCOUNT_ID`. This change reflects our efforts to be consistent in how we refer to concepts in HubSpot.
+
 ## Usage
 In your GitHub repo, create two new [secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for:
 - `HUBSPOT_ACCOUNT_ID` - This is your HubSpot account ID

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Automatically deploy a HubSpot CMS project to your account 🚀
 
 ## Usage
 In your GitHub repo, create two new [secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for:
-- `HUBSPOT_PORTAL_ID` - This is your HubSpot account ID
+- `HUBSPOT_ACCOUNT_ID` - This is your HubSpot account ID
 - `HUBSPOT_PERSONAL_ACCESS_KEY` - Your [personal access key](https://developers.hubspot.com/docs/cms/personal-cms-access-key)
 
 This guide walks through setting up a new workflow file that automatically uploads new changes on your `main` branch to your HubSpot CMS account. If you're adding a deployment step to an existing workflow, you can [skip ahead](#integrating-into-an-existing-workflow).
@@ -27,14 +27,14 @@ jobs:
         with:
           src_dir: <src> ## ex. src
           dest_dir: <src> ## ex. my-theme
-          portal_id: ${{ secrets.hubspot_portal_id }}
+          account_id: ${{ secrets.hubspot_portal_id }}
           personal_access_key: ${{ secrets.hubspot_personal_access_key }}
 ```
 3. Replace the `src_dir` with the directory of your CMS project in your repo
 4. Replace the `dest_dir` with the directory it should be uploaded to in your target account
 5. Commit and merge your changes
 
-*Note:* Do not change the `portal_id` or `personal_access_key` values in your workflow. Auth related values should only be stored as GitHub secrets.
+*Note:* Do not change the `account_id` or `personal_access_key` values in your workflow. Auth related values should only be stored as GitHub secrets.
 
 ### Deploying to a staging account
 If you'd like to auto-deploy to a staging account you have in HubSpot, you can create an additional workflow that runs on `push` to your associated stanging branch in your repo.
@@ -44,7 +44,7 @@ on:
     branches:
     - qa
 ...
-portal_id: ${{ secrets.staging_account_id }}
+account_id: ${{ secrets.staging_account_id }}
 ```
 
 ### Integrating into an existing workflow
@@ -55,7 +55,7 @@ To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, a
   with:
     src_dir: <src> ## ex. src
     dest_dir: <src> ## ex. my-theme
-    portal_id: ${{ secrets.hubspot_portal_id }}
+    account_id: ${{ secrets.hubspot_portal_id }}
     personal_access_key: ${{ secrets.hubspot_personal_access_key }}
 ```
 
@@ -67,5 +67,5 @@ To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, a
 - `dest_dir` - Target directory in HubSpot
 
 ### Secrets
-- `HUBSPOT_PORTAL_ID` - Target account id
+- `HUBSPOT_ACCOUNT_ID` - Target account id
 - `HUBSPOT_PERSONAL_ACCESS_KEY` - Authentication key

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, a
 - `src_dir` - Project directory relative to the repo
 - `dest_dir` - Target directory in HubSpot
 
-### Secrets
-- `HUBSPOT_PERSONAL_ACCESS_KEY` - Authentication key
-
-#### Deprecated secret
-- `HUBSPOT_PORTAL_ID` - Target account id. This was deprecated in favor of `HUBSPOT_ACCOUNT_ID`, this is more consistent with how we refer to accounts, additionally we moved it to be a variable since GitHub variables now exist and allow for you to be able to see and modify the value. The Account ID does not need the same protection that an authentication key does.
 ### Variables
 - `HUBSPOT_ACCOUNT_ID` - Target account id
+### Secrets
+- `HUBSPOT_PERSONAL_ACCESS_KEY` - Authentication key
+#### Deprecated secret
+- `HUBSPOT_PORTAL_ID` - Target account id. This was deprecated in favor of `HUBSPOT_ACCOUNT_ID`, this is more consistent with how we refer to accounts, additionally we moved it to be a variable since GitHub variables now exist and allow for you to be able to see and modify the value. The Account ID does not need the same protection that an authentication key does.
+

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,10 @@ runs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: "20.x"
+        node-version: "22.x"
     - name: Deploy
       env:
-        HUBSPOT_PORTAL_ID: ${{ inputs.portal_id }}
+        HUBSPOT_ACCOUNT_ID: ${{ inputs.portal_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
         npx --yes --package=@hubspot/cli@latest --call='hs upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   dest_dir:
     description: Directory in account which project will be published to
     require: true
-  portal_id:
+  account_id:
     description: Target HubSpot account (Should be stored in secrets)
     required: true
   personal_access_key:
@@ -26,7 +26,7 @@ runs:
         node-version: "22.x"
     - name: Deploy
       env:
-        HUBSPOT_ACCOUNT_ID: ${{ inputs.portal_id }}
+        HUBSPOT_ACCOUNT_ID: ${{ inputs.account_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
         npx --yes --package=@hubspot/cli@latest --call='hs upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: HubSpot CMS Deploy
 author: HubSpot
-description: Publish website files to your HubSpot CMS account
+description: Publish website files to your HubSpot account
 branding:
   icon: "upload-cloud"
   color: "orange"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-cms-deploy",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Publish website files to your HubSpot CMS account",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes:

- updating to no longer use secret `HUBSPOT_PORTAL_ID`, instead we're using a variable named `HUBSPOT_ACCOUNT_ID` for consistency.

- Upped Node version to 22.

- Upped Checkout version to 4

- Updated Readme instructions to reflect the above changes, also updated the readme examples to use only the major version for the GitHub Deploy Action, this will enable the action to use the latest minor version, enabling the ability to resolve issues faster and make some changes faster.