### PR TITLE
update setup-node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: "22.x"
     - name: Deploy


### PR DESCRIPTION
updating the setup node version while I'm at it since there's a PR someone submitted for this but it has an older version of node in it.

Also testing GH Actions Marketplace's ability to pin versions properly. So far it seems only pinning specific version numbers is working, not supporting automatically using the latest minor and patch version within a major version.
🧐