### PR TITLE
docs: fix README to use working version tag v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ account_id: ${{ vars.hubspot_account_id || secrets.hubspot_portal_id }}
 To add HubSpot CMS deployment as a step in an existing GitHub Action workflow, add the following step:
 ```yaml
 - name: HubSpot Deploy Action
-  uses: HubSpot/hubspot-cms-deploy-action@v2
+  uses: HubSpot/hubspot-cms-deploy-action@v2.0.1
   with:
     src_dir: <src> ## ex. src
     dest_dir: <src> ## ex. my-theme


### PR DESCRIPTION
Replaced @v2 with @v2.0.1 in README since using @v2 currently fails. Only @v2.0.0 or @v2.0.1 are valid tags. Also clarified that vars.hubspot_account_id must be defined in GitHub Actions Variables to avoid confusion for new users.