### PR TITLE
Use new upload command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ runs:
         HUBSPOT_ACCOUNT_ID: ${{ inputs.account_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
-        npx --yes --package=@hubspot/cli@^7 --call='hs cms upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'
+        npx --yes --package=@hubspot/cli@^7.9.0 --call='hs cms upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'
       shell: bash


### PR DESCRIPTION
The cms upload command has been moved as of cli version 7.9.0. The old command still exists for now, but we should update this anyways.