### PR TITLE
Pin CLI version to 7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ runs:
         HUBSPOT_PORTAL_ID: ${{ inputs.portal_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
-        npx --yes --package=@hubspot/cli@latest --call='hs upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'
+        npx --yes --package=@hubspot/cli@7 --call='hs upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'
       shell: bash


### PR DESCRIPTION
### Description
This pins the version of the HubSpot CLI run by `npx` to version 7 so that breaking changes to the CLI don't impact this Github action.

### Reviewers
@brandenrodgers @joe-yeager @chiragchadha1 