### PR TITLE
Update HubSpot CLI package version to 8.6.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ runs:
         HUBSPOT_ACCOUNT_ID: ${{ inputs.account_id }}
         HUBSPOT_PERSONAL_ACCESS_KEY: ${{ inputs.personal_access_key }}
       run: |
-        npx --yes --package=@hubspot/cli@^7.9.0 --call='hs cms upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'
+        npx --yes --package=@hubspot/cli@^8.6.0 --call='hs cms upload ${{ inputs.src_dir }} ${{ inputs.dest_dir }} --use-env'
       shell: bash


### PR DESCRIPTION
This pull request updates the HubSpot CLI version used in the GitHub Action to ensure compatibility with the latest features and bug fixes.

Dependency update:

* Updated the `@hubspot/cli` package from version `^7.9.0` to `^8.6.0` in the `action.yml` file to use the latest CLI version for CMS uploads.