### PR TITLE
Bump actions/setup-node v4 -> v6 (Node 24 runtime)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "22.x"
     - name: Deploy


### PR DESCRIPTION
**What** — Bumps `actions/setup-node` from `@v4` to `@v6` in the composite action.

**Why** — `actions/setup-node@v4` runs on the **Node 20** runtime. With GitHub's deprecation of Node 20 in Actions, every workflow consuming this action now surfaces a `node20` deprecation warning — and during the transition GitHub force-runs the step on Node 24, ahead of Node 20's removal from hosted runners later this year. It isn't breaking today, so this is housekeeping — but it clears the warning for everyone using the action and gets ahead of the runner removal.

`setup-node@v5+` runs on Node 24; `v6` is the latest. Drop-in for the current usage — `node-version: "22.x"` is unchanged, and `actions/checkout` consumers are already on a Node 24-class version, so this just brings `setup-node` in line.

```diff
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
```

---
*Minor aside, unrelated to this PR (happy to send a separate one if useful): `dest_dir` on line 13 uses `require: true`, which looks like a typo for `required: true` — as written the key is ignored, so the input isn't actually enforced as required.*
